### PR TITLE
Add pre-commit hooks; consolidate CI lint on them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,26 +13,16 @@ concurrency:
 
 jobs:
   lint:
-    name: Lint and format check
+    name: Pre-commit hooks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: pyproject.toml
 
-      - name: Install
-        run: pip install -e ".[dev]"
-
-      - name: ruff check
-        run: ruff check .
-
-      - name: ruff format --check
-        run: ruff format --check .
+      - uses: pre-commit/action@v3.0.1
 
   test:
     name: Tests (Python ${{ matrix.python-version }})

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,23 @@
+# Pre-commit hooks. After cloning, run once: pre-commit install
+# CI runs `pre-commit run --all-files`, so what you see locally is what CI checks.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: check-added-large-files
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: mixed-line-ending
+      - id: debug-statements
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.8.6
+    hooks:
+      - id: ruff
+        args: [--fix]
+      - id: ruff-format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ The default branch is `main` (renamed from `master`); the old `development` bran
 ## Commands
 
 ```bash
-# Install (Python 3.10+ venv). [dev] adds pytest + ruff.
+# Install (Python 3.10+ venv). [dev] adds pytest + ruff + pre-commit.
 pip install -e ".[dev]"
 
 # Run the dev server (Flask debug mode, port 5000)
@@ -28,10 +28,10 @@ pytest                                                    # full suite
 pytest steel_pigs/tests/test_flask_app.py                 # one file
 pytest steel_pigs/tests/test_flask_app.py::TestFlaskApp::test_versions_json
 
-# Lint / format
-ruff check .
-ruff format .
-ruff format --check .   # CI mode (no writes)
+# Lint / format -- pre-commit drives ruff + hygiene hooks (CI runs the same)
+pre-commit install              # one-time, sets up the git hook
+pre-commit run --all-files      # run every hook against the whole tree
+ruff check . && ruff format .   # if you want to skip pre-commit and just run ruff
 ```
 
 ## Environment variables

--- a/LICENSE
+++ b/LICENSE
@@ -199,4 +199,3 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/README.rst
+++ b/README.rst
@@ -50,10 +50,16 @@ Contributing
 Fork the repo, create a feature branch, open a pull request against
 ``main``. Tests are required where applicable.
 
-Lint and format with ruff before pushing ::
+After cloning, install the pre-commit hooks once. They run ruff and a
+handful of hygiene checks on every commit, and CI runs the same hooks
+so what you see locally is what CI checks ::
 
-    ruff check .
-    ruff format .
+    pre-commit install
+
+Run all hooks against the whole tree before pushing if you want to be
+sure ::
+
+    pre-commit run --all-files
 
 Run the test suite with pytest ::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest>=8.0"]
-dev = ["pytest>=8.0", "ruff>=0.6"]
+dev = ["pytest>=8.0", "ruff>=0.6", "pre-commit>=4.0"]
 
 [project.urls]
 Homepage = "https://github.com/virtdevninja/steel_pigs"


### PR DESCRIPTION
Adds .pre-commit-config.yaml with:
* ruff (with --fix) and ruff-format from astral-sh/ruff-pre-commit
* pre-commit/pre-commit-hooks for hygiene: trailing-whitespace, end-of-file-fixer, check-yaml, check-toml, check-added-large-files, check-merge-conflict, check-case-conflict, mixed-line-ending, debug-statements

Adds pre-commit to the [dev] extras so `pip install -e ".[dev]"` brings it in.

Replaces the CI lint job's ruff calls with `pre-commit/action@v3.0.1` so local hooks and CI run the exact same checks. The action handles caching of the hook environments.

LICENSE picks up an end-of-file-fixer trim (one trailing blank line).

README Contributing section now points contributors at `pre-commit install`; CLAUDE.md updates the lint commands.