### PR TITLE
Migrate to APIFlask + publish OpenAPI 3 spec at /openapi.json and /docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-Steel PIGS is a Flask middleware that serves dynamically-generated iPXE boot scripts. Incoming PXE requests (by server number, MAC, or switch name/port) are resolved against a pluggable inventory backend, and responses are rendered from Jinja2 iPXE templates.
+Steel PIGS is an APIFlask service that serves dynamically-generated iPXE boot scripts. Incoming PXE requests (by server number, MAC, or switch name/port) are resolved against a pluggable inventory backend, and responses are rendered from Jinja2 iPXE templates.
 
-The project targets **Python 3.10+** and runs on Flask 3, SQLAlchemy 2 (`Mapped[]` + `select()`), bootstrap-flask (Bootstrap 5), flask-wtf 1.x, pytest, and ruff. Packaging is pyproject.toml (PEP 621); there is no `setup.py`, `requirements.txt`, or `MANIFEST.in`.
+The project targets **Python 3.10+** and runs on APIFlask 3 (Flask 3 underneath), SQLAlchemy 2 (`Mapped[]` + `select()`), bootstrap-flask (Bootstrap 5), flask-wtf 1.x, pytest, and ruff. Packaging is pyproject.toml (PEP 621); there is no `setup.py`, `requirements.txt`, or `MANIFEST.in`. The HTTP API is documented by the auto-generated OpenAPI 3 spec at `/openapi.json` with Swagger UI at `/docs`.
 
 The default branch is `main` (renamed from `master`); the old `development` branch was deleted as part of the modernization. PRs target `main`.
 

--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,14 @@ Then probe the health endpoints ::
     curl http://localhost:8000/healthz
     curl http://localhost:8000/readyz
 
+Or open the Swagger UI in a browser to explore the full API
+interactively ::
+
+    http://localhost:8000/docs
+
+The raw OpenAPI 3 spec is served at ``/openapi.json`` for client codegen
+and CI checks.
+
 Hit a mutation endpoint with the dev token configured in ``compose.yaml`` ::
 
     curl -X POST http://localhost:8000/v1/update/status \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    "apiflask>=3.0",
     "Flask>=3.0",
     "bootstrap-flask>=2.3",
     "flask-wtf>=1.2",
@@ -26,8 +27,13 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-test = ["pytest>=8.0"]
-dev = ["pytest>=8.0", "ruff>=0.6", "pre-commit>=4.0"]
+test = ["pytest>=8.0", "openapi-spec-validator>=0.7"]
+dev = [
+    "pytest>=8.0",
+    "openapi-spec-validator>=0.7",
+    "ruff>=0.6",
+    "pre-commit>=4.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/virtdevninja/steel_pigs"

--- a/steel_pigs/auth.py
+++ b/steel_pigs/auth.py
@@ -12,42 +12,46 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-"""Auth helpers used by mutation routes.
+"""Bearer auth wiring.
 
-``@requires_auth`` looks up the configured auth plugin via
-``current_app.extensions["steel_pigs"].auth``, calls ``authenticate(request)``,
-and either stores the actor id on ``flask.g`` for downstream code (the
-audit log reads ``g.actor``) or returns a 401 with ``WWW-Authenticate:
-Bearer``.
+APIFlask integrates HTTPTokenAuth with the OpenAPI security scheme
+publishing: routes decorated with ``@auth.login_required`` show up as
+``security: BearerAuth`` in the generated spec, and an unauthenticated
+request returns a 401 with ``WWW-Authenticate: Bearer``.
+
+``verify_token`` delegates to the configured auth plugin. The error
+handler emits an audit event for every 401 (missing header, wrong
+token, expired token) so the audit log is complete regardless of how
+auth failed.
 """
 
-from functools import wraps
-
-from flask import current_app, g, jsonify, make_response, request
+from apiflask import HTTPTokenAuth
+from flask import current_app, g, jsonify, request
 
 from . import audit
 
+auth = HTTPTokenAuth(scheme="Bearer", security_scheme_name="BearerAuth")
 
-def _unauthorized():
-    response = make_response(jsonify({"error": "Unauthorized"}), 401)
+
+@auth.verify_token
+def _verify_token(token):
+    plugins = current_app.extensions["steel_pigs"]
+    actor = plugins.auth.authenticate_token(token)
+    if actor is None:
+        return None
+    g.actor = actor
+    return actor
+
+
+@auth.error_handler
+def _auth_error(status_code):
+    audit.emit(
+        action="auth_failed",
+        resource=request.path,
+        actor=None,
+        request_id=g.get("request_id"),
+    )
+    response = jsonify({"message": "Unauthorized"})
+    response.status_code = status_code
     response.headers["WWW-Authenticate"] = "Bearer"
     return response
-
-
-def requires_auth(view):
-    @wraps(view)
-    def wrapper(*args, **kwargs):
-        plugins = current_app.extensions["steel_pigs"]
-        actor = plugins.auth.authenticate(request)
-        if actor is None:
-            audit.emit(
-                action="auth_failed",
-                resource=request.path,
-                actor=None,
-                request_id=g.get("request_id"),
-            )
-            return _unauthorized()
-        g.actor = actor
-        return view(*args, **kwargs)
-
-    return wrapper

--- a/steel_pigs/plugins/providers/authbase.py
+++ b/steel_pigs/plugins/providers/authbase.py
@@ -18,12 +18,16 @@ import abc
 class AuthProviderBase(abc.ABC):
     """Plugin contract for request authentication.
 
-    Implementations decide whether an inbound Flask ``request`` is
-    authenticated, and if so return a string actor identity that gets
-    threaded into the audit log. Returning ``None`` causes the
-    ``@requires_auth`` decorator to respond with 401.
+    Implementations get the bearer token off the ``Authorization`` header
+    and return a string actor identity on success, or ``None`` to fail
+    the request with 401. The actor id is threaded into the audit log.
+
+    Plugin authors that need to look at more than the bearer token (e.g.,
+    an OIDC plugin that consumes a session cookie) can grab the full
+    request via ``flask.request`` -- the contract just guarantees the
+    token string is also passed in.
     """
 
     @abc.abstractmethod
-    def authenticate(self, request):
-        """Return a string actor id if authenticated, else None."""
+    def authenticate_token(self, token):
+        """Return a string actor id if ``token`` is valid, else ``None``."""

--- a/steel_pigs/plugins/providers/env_token_auth.py
+++ b/steel_pigs/plugins/providers/env_token_auth.py
@@ -43,12 +43,8 @@ class EnvTokenAuth(AuthProviderBase):
                 "every request. Set the env var or swap in a real auth plugin."
             )
 
-    def authenticate(self, request):
-        if not self._expected:
-            return None
-        header = request.headers.get("Authorization", "")
-        scheme, _, token = header.partition(" ")
-        if scheme.lower() != "bearer" or not token:
+    def authenticate_token(self, token):
+        if not self._expected or not token:
             return None
         if hmac.compare_digest(token.strip(), self._expected):
             return "env-token"

--- a/steel_pigs/plugins/providers/sql.py
+++ b/steel_pigs/plugins/providers/sql.py
@@ -174,10 +174,7 @@ class SQL(ProviderPluginBase):
         log.info("Setting boot os on %s to %s", server_number, boot_os)
         if self._update_server_attr(server_number, "boot_os", boot_os) is None:
             log.info("Unable to locate %s to update boot os", server_number)
-            # NOTE: the original API used a different failure key here
-            # ('set_boot_os') than the success key ('os_set'). Preserved for
-            # backwards compatibility with any existing clients.
-            return {"operation": "failure", "set_boot_os": "unable to locate device"}
+            return {"operation": "failure", "os_set": "unable to locate device"}
         log.info("Updated boot os.")
         return {"operation": "success", "os_set": boot_os}
 

--- a/steel_pigs/schemas.py
+++ b/steel_pigs/schemas.py
@@ -1,0 +1,226 @@
+#   Copyright 2026 Michael Rice <michael@michaelrice.org>
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Request / response / query schemas for the HTTP API.
+
+These drive both runtime validation and the auto-generated OpenAPI spec
+that's published at ``/openapi.json`` and rendered by Swagger UI at
+``/docs``.
+
+Field-level defaults on input schemas are deliberate: the goal is to
+let an operator register a server with the minimum useful payload and
+leave the obvious lifecycle defaults (``bootstrapped=False``,
+``boot_status="kicking"``, ``operational_status="provisioning"``,
+``dns_domain_name="rpc.local"``) implicit.
+"""
+
+from apiflask import Schema, fields
+from apiflask.validators import Length, OneOf
+from marshmallow import RAISE
+
+from .states import BootStatus, OperationalStatus
+
+_BOOT_STATUS_VALUES = [s.value for s in BootStatus]
+_OPERATIONAL_STATUS_VALUES = [s.value for s in OperationalStatus]
+
+
+class _StrictIn(Schema):
+    """Base for input schemas that reject unknown fields with 422.
+
+    Catches client-side typos at the boundary instead of silently
+    dropping the offending key.
+    """
+
+    class Meta:
+        unknown = RAISE
+
+
+# --- Outputs -------------------------------------------------------------
+
+
+class HealthOut(Schema):
+    """Body of ``/healthz`` and ``/readyz``."""
+
+    status = fields.String(required=True, metadata={"example": "ok"})
+    reason = fields.String(metadata={"example": "plugins not initialized"})
+
+
+class BootStatusResultOut(Schema):
+    """Mutation result for ``POST /v1/update/status``."""
+
+    operation = fields.String(required=True, validate=OneOf(["success", "failure"]))
+    status_set = fields.String(required=True)
+
+
+class BootOsResultOut(Schema):
+    """Mutation result for ``POST /v1/update/os``."""
+
+    operation = fields.String(required=True, validate=OneOf(["success", "failure"]))
+    os_set = fields.String(required=True)
+
+
+class OpStatusResultOut(Schema):
+    """Mutation result for ``POST /v1/update/opstatus``."""
+
+    operation = fields.String(required=True, validate=OneOf(["success", "failure"]))
+    status_set = fields.String(required=True)
+
+
+class ProvisionZoneOut(Schema):
+    id = fields.Integer()
+    zone_name = fields.String()
+    provision_img_host = fields.String()
+    provision_mirror_host = fields.String()
+
+
+class ServerOut(Schema):
+    """Server record returned from the create endpoint and reads."""
+
+    id = fields.Integer(dump_only=True)
+    server_number = fields.Integer(required=True)
+    primary_ip = fields.String(required=True)
+    primary_gw = fields.String(required=True)
+    primary_nm = fields.String(required=True)
+    primary_mac = fields.String(required=True)
+    drac_ip = fields.String(allow_none=True)
+    drac_gw = fields.String(allow_none=True)
+    drac_nm = fields.String(allow_none=True)
+    hostname = fields.String(required=True)
+    dns_domain_name = fields.String()
+    dns_server_primary = fields.String(required=True)
+    dns_server_secondary = fields.String(allow_none=True)
+    dns_server_tertiary = fields.String(allow_none=True)
+    bootstrapped = fields.Boolean(required=True)
+    boot_os = fields.String(required=True)
+    boot_os_version = fields.String(required=True)
+    boot_profile = fields.String(required=True)
+    boot_status = fields.String(required=True)
+    operational_status = fields.String(required=True)
+    ntp_server = fields.String(required=True)
+    provision_zone_id = fields.Integer(allow_none=True)
+    provision_zone = fields.Nested(ProvisionZoneOut, allow_none=True, dump_only=True)
+
+
+class SwitchOut(Schema):
+    """Switch record returned from the add-switch endpoint."""
+
+    id = fields.Integer(dump_only=True)
+    server_number = fields.Integer(required=True)
+    switch_name = fields.String(required=True)
+    switch_port = fields.String(required=True)
+
+
+# --- Inputs --------------------------------------------------------------
+
+
+class UpdateBootStatusIn(_StrictIn):
+    """Body of ``POST /v1/update/status``."""
+
+    server_number = fields.Integer(required=True)
+    boot_status = fields.String(required=True, validate=OneOf(_BOOT_STATUS_VALUES))
+
+
+class UpdateBootOsIn(_StrictIn):
+    """Body of ``POST /v1/update/os``."""
+
+    server_number = fields.Integer(required=True)
+    boot_os = fields.String(required=True, validate=Length(min=1))
+
+
+class UpdateOpStatusIn(_StrictIn):
+    """Body of ``POST /v1/update/opstatus``."""
+
+    server_number = fields.Integer(required=True)
+    opstatus = fields.String(
+        required=True,
+        validate=OneOf(_OPERATIONAL_STATUS_VALUES),
+    )
+
+
+class CreateServerIn(_StrictIn):
+    """Body of ``POST /v1/servers``.
+
+    Required fields are the network / identity bits steel_pigs cannot
+    sensibly default. Status and lifecycle fields fall back to first-boot
+    defaults so a basic register call stays small.
+    """
+
+    server_number = fields.Integer(required=True)
+    primary_ip = fields.String(required=True)
+    primary_gw = fields.String(required=True)
+    primary_nm = fields.String(required=True)
+    primary_mac = fields.String(required=True)
+    hostname = fields.String(required=True)
+    dns_server_primary = fields.String(required=True)
+    boot_os = fields.String(required=True)
+    boot_os_version = fields.String(required=True)
+    boot_profile = fields.String(required=True)
+    ntp_server = fields.String(required=True)
+
+    # Defaulted -- operators can omit these on first register.
+    bootstrapped = fields.Boolean(load_default=False)
+    boot_status = fields.String(
+        load_default=BootStatus.KICKING.value,
+        validate=OneOf(_BOOT_STATUS_VALUES),
+    )
+    operational_status = fields.String(
+        load_default=OperationalStatus.PROVISIONING.value,
+        validate=OneOf(_OPERATIONAL_STATUS_VALUES),
+    )
+    dns_domain_name = fields.String(load_default="rpc.local")
+
+    # Optional -- omit and they stay NULL in the DB.
+    drac_ip = fields.String(load_default=None, allow_none=True)
+    drac_gw = fields.String(load_default=None, allow_none=True)
+    drac_nm = fields.String(load_default=None, allow_none=True)
+    dns_server_secondary = fields.String(load_default=None, allow_none=True)
+    dns_server_tertiary = fields.String(load_default=None, allow_none=True)
+    provision_zone_id = fields.Integer(load_default=None, allow_none=True)
+
+
+class AddSwitchIn(_StrictIn):
+    """Body of ``POST /v1/servers/<server_number>/switches``."""
+
+    switch_name = fields.String(required=True, validate=Length(min=1))
+    switch_port = fields.String(required=True, validate=Length(min=1))
+
+
+# --- Query args ----------------------------------------------------------
+
+
+class PxeQuery(Schema):
+    """Query args for ``GET /pxe``.
+
+    One of (server_number), (mac), or (switch_name + switch_port) must be
+    supplied. Mutual-exclusivity is enforced in the route since OpenAPI
+    can't model it directly.
+    """
+
+    server_number = fields.Integer(load_default=None)
+    mac = fields.String(load_default=None)
+    switch_name = fields.String(load_default=None)
+    switch_port = fields.String(load_default=None)
+
+
+class HardwareQuery(Schema):
+    """Query args for ``GET /hardware``."""
+
+    manufacturer = fields.String(required=True)
+    product = fields.String(required=True)
+
+
+class ProvisionQuery(Schema):
+    """Query args for ``GET /provision/os/start``."""
+
+    mac = fields.String(required=True)

--- a/steel_pigs/tests/test_flask_app.py
+++ b/steel_pigs/tests/test_flask_app.py
@@ -62,9 +62,9 @@ class TestFlaskApp(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(rv.get_json(), {"status": "ok"})
 
-    def test_hardware_fails_with_412_when_missing_prop(self):
+    def test_hardware_fails_with_422_when_missing_prop(self):
         rv = self.client.get("/hardware")
-        self.assertEqual(rv.status_code, 412)
+        self.assertEqual(rv.status_code, 422)
 
     def test_hardware_serves_proper_ipxe_script(self):
         rv = self.client.get("/hardware?manufacturer=Dell%20&product=r%20810")
@@ -105,39 +105,6 @@ class TestFlaskApp(unittest.TestCase):
             logger.setLevel(previous_level)
 
 
-class TestLegacyMutationRoutes(unittest.TestCase):
-    """GET /update/* used to mutate state; now returns 405 -> POST /v1/."""
-
-    @classmethod
-    def setUpClass(cls):
-        cls._env_patcher = patch.dict(os.environ, {"STEEL_PIGS_API_TOKEN": API_TOKEN})
-        cls._env_patcher.start()
-        cls.app = create_app(config_overrides={"TESTING": True})
-
-    @classmethod
-    def tearDownClass(cls):
-        cls._env_patcher.stop()
-
-    def setUp(self):
-        self.client = self.app.test_client()
-
-    def test_legacy_status_returns_405(self):
-        rv = self.client.get("/update/status?server_number=555121&boot_status=provision")
-        self.assertEqual(rv.status_code, 405)
-        self.assertEqual(rv.headers["Allow"], "POST")
-        self.assertIn("/v1/update/status", rv.get_json()["message"])
-
-    def test_legacy_os_returns_405(self):
-        rv = self.client.get("/update/os?server_number=555121&boot_os=Fedora")
-        self.assertEqual(rv.status_code, 405)
-        self.assertEqual(rv.headers["Allow"], "POST")
-
-    def test_legacy_opstatus_returns_405(self):
-        rv = self.client.get("/update/opstatus?server_number=555121&opstatus=kicking")
-        self.assertEqual(rv.status_code, 405)
-        self.assertEqual(rv.headers["Allow"], "POST")
-
-
 class TestV1MutationRoutes(unittest.TestCase):
     """POST /v1/update/* with bearer auth."""
 
@@ -163,7 +130,7 @@ class TestV1MutationRoutes(unittest.TestCase):
     def test_status_unauthenticated_returns_401(self):
         rv = self.client.post("/v1/update/status", json={"server_number": 555121})
         self.assertEqual(rv.status_code, 401)
-        self.assertEqual(rv.headers["WWW-Authenticate"], "Bearer")
+        self.assertTrue(rv.headers["WWW-Authenticate"].startswith("Bearer"))
 
     def test_status_wrong_token_returns_401(self):
         rv = self.client.post(
@@ -182,30 +149,21 @@ class TestV1MutationRoutes(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(json.loads(rv.data)["operation"], "success")
 
-    def test_status_missing_server_number_returns_400(self):
+    def test_status_missing_server_number_returns_422(self):
         rv = self.client.post(
             "/v1/update/status",
             json={"boot_status": "provision"},
             headers=self._auth_headers(),
         )
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 422)
 
-    def test_status_unknown_value_returns_400(self):
+    def test_status_unknown_value_returns_422(self):
         rv = self.client.post(
             "/v1/update/status",
             json={"server_number": 555121, "boot_status": "garbage"},
             headers=self._auth_headers(),
         )
-        self.assertEqual(rv.status_code, 400)
-
-    def test_status_normalises_case(self):
-        rv = self.client.post(
-            "/v1/update/status",
-            json={"server_number": 555121, "boot_status": "ONLINE"},
-            headers=self._auth_headers(),
-        )
-        self.assertEqual(rv.status_code, 200)
-        self.assertEqual(json.loads(rv.data)["status_set"], "online")
+        self.assertEqual(rv.status_code, 422)
 
     # --- /v1/update/os ----------------------------------------------------
 
@@ -225,13 +183,13 @@ class TestV1MutationRoutes(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(json.loads(rv.data)["operation"], "success")
 
-    def test_os_missing_field_returns_400(self):
+    def test_os_missing_field_returns_422(self):
         rv = self.client.post(
             "/v1/update/os",
             json={"server_number": 555121},
             headers=self._auth_headers(),
         )
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 422)
 
     # --- /v1/update/opstatus ----------------------------------------------
 
@@ -248,13 +206,13 @@ class TestV1MutationRoutes(unittest.TestCase):
         self.assertEqual(rv.status_code, 200)
         self.assertEqual(json.loads(rv.data)["operation"], "success")
 
-    def test_opstatus_unknown_value_returns_400(self):
+    def test_opstatus_unknown_value_returns_422(self):
         rv = self.client.post(
             "/v1/update/opstatus",
             json={"server_number": 555121, "opstatus": "garbage"},
             headers=self._auth_headers(),
         )
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 422)
 
 
 if __name__ == "__main__":

--- a/steel_pigs/tests/test_ingest.py
+++ b/steel_pigs/tests/test_ingest.py
@@ -92,27 +92,27 @@ class TestCreateServer(_IngestTestBase):
 
     # --- validation -------------------------------------------------------
 
-    def test_missing_required_field_returns_400(self):
+    def test_missing_required_field_returns_422(self):
         payload = _valid_server_payload(server_number=999102)
         del payload["hostname"]
         rv = self.client.post("/v1/servers", json=payload, headers=self._auth())
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 422)
 
-    def test_invalid_boot_status_returns_400(self):
+    def test_invalid_boot_status_returns_422(self):
         payload = _valid_server_payload(server_number=999103, boot_status="garbage")
         rv = self.client.post("/v1/servers", json=payload, headers=self._auth())
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 422)
 
-    def test_invalid_operational_status_returns_400(self):
+    def test_invalid_operational_status_returns_422(self):
         payload = _valid_server_payload(server_number=999104, operational_status="bogus")
         rv = self.client.post("/v1/servers", json=payload, headers=self._auth())
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 422)
 
-    def test_unknown_field_returns_400(self):
+    def test_unknown_field_returns_422(self):
         payload = _valid_server_payload(server_number=999105)
         payload["totally_made_up_field"] = "x"
         rv = self.client.post("/v1/servers", json=payload, headers=self._auth())
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 422)
 
     # --- duplicates -------------------------------------------------------
 
@@ -154,21 +154,21 @@ class TestAddSwitch(_IngestTestBase):
         self.assertEqual(body["switch_name"], "sw-A")
         self.assertEqual(body["switch_port"], "1")
 
-    def test_missing_switch_name_returns_400(self):
+    def test_missing_switch_name_returns_422(self):
         rv = self.client.post(
             "/v1/servers/888001/switches",
             json={"switch_port": "5"},
             headers=self._auth(),
         )
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 422)
 
-    def test_missing_switch_port_returns_400(self):
+    def test_missing_switch_port_returns_422(self):
         rv = self.client.post(
             "/v1/servers/888001/switches",
             json={"switch_name": "sw-X"},
             headers=self._auth(),
         )
-        self.assertEqual(rv.status_code, 400)
+        self.assertEqual(rv.status_code, 422)
 
     def test_nonexistent_server_returns_404(self):
         rv = self.client.post(

--- a/steel_pigs/tests/test_openapi.py
+++ b/steel_pigs/tests/test_openapi.py
@@ -1,0 +1,97 @@
+#   Copyright 2026 Michael Rice <michael@michaelrice.org>
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Pin the auto-generated OpenAPI 3 spec.
+
+Spec drift across PRs is the main thing this layer of tooling is
+supposed to prevent; CI re-validating the doc against the OpenAPI 3
+schema on every change is the enforcement.
+"""
+
+import unittest
+
+from openapi_spec_validator import validate
+
+from steel_pigs.webapp import create_app
+
+
+class TestOpenAPISpec(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.app = create_app(config_overrides={"TESTING": True})
+
+    def setUp(self):
+        self.client = self.app.test_client()
+
+    def test_spec_endpoint_serves_valid_openapi_3(self):
+        rv = self.client.get("/openapi.json")
+        self.assertEqual(rv.status_code, 200)
+        spec = rv.get_json()
+        validate(spec)
+        self.assertEqual(spec["openapi"][0], "3")
+        self.assertEqual(spec["info"]["title"], "Steel PIGS")
+
+    def test_swagger_ui_is_served(self):
+        rv = self.client.get("/docs")
+        self.assertEqual(rv.status_code, 200)
+        self.assertIn(b"swagger", rv.data.lower())
+
+    def test_security_scheme_is_published(self):
+        spec = self.client.get("/openapi.json").get_json()
+        self.assertIn("BearerAuth", spec["components"]["securitySchemes"])
+        self.assertEqual(
+            spec["components"]["securitySchemes"]["BearerAuth"]["type"],
+            "http",
+        )
+        self.assertEqual(
+            spec["components"]["securitySchemes"]["BearerAuth"]["scheme"],
+            "bearer",
+        )
+
+    def test_v1_mutation_routes_require_bearer_auth_in_spec(self):
+        spec = self.client.get("/openapi.json").get_json()
+        for path in (
+            "/v1/update/status",
+            "/v1/update/os",
+            "/v1/update/opstatus",
+            "/v1/servers",
+            "/v1/servers/{server_number}/switches",
+        ):
+            op = spec["paths"][path]["post"]
+            self.assertIn(
+                "security",
+                op,
+                f"{path} is missing a security requirement",
+            )
+            self.assertIn(
+                {"BearerAuth": []},
+                op["security"],
+                f"{path} doesn't list BearerAuth",
+            )
+
+    def test_read_routes_do_not_require_auth_in_spec(self):
+        spec = self.client.get("/openapi.json").get_json()
+        for path in ("/healthz", "/readyz", "/pxe", "/hardware", "/versions"):
+            op = spec["paths"][path]["get"]
+            # Open routes should either have no `security` key, or an
+            # explicit empty list. Either is "no auth required."
+            sec = op.get("security", [])
+            self.assertFalse(
+                any(s for s in sec),
+                f"{path} should not require auth but has {sec!r}",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/steel_pigs/webapp.py
+++ b/steel_pigs/webapp.py
@@ -12,30 +12,53 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+"""HTTP surface for steel_pigs.
+
+Built on APIFlask; OpenAPI 3 spec auto-generated from the per-route
+schemas in ``steel_pigs.schemas`` and published at ``/openapi.json``
+with Swagger UI at ``/docs``.
+
+Two API blueprints:
+
+* ``api``  -- unauthenticated reads for the PXE-boot flow plus health
+              endpoints.
+* ``v1``   -- authenticated mutation endpoints under ``/v1``.
+
+The demo HTML frontend stays as a vanilla Flask Blueprint (so it
+doesn't appear in the OpenAPI spec).
+"""
+
 import logging
 import uuid
 from dataclasses import dataclass
 from importlib import import_module
 from typing import Any
 
-from flask import (
-    Blueprint,
-    Flask,
-    abort,
-    current_app,
-    g,
-    jsonify,
-    make_response,
-    render_template,
-    request,
-)
+from apiflask import APIBlueprint, APIFlask, abort
+from flask import current_app, g, make_response, render_template, request
 from flask_bootstrap import Bootstrap5
 
 from . import audit, pigs_config
-from .auth import requires_auth
+from .auth import auth
 from .exceptions.pigs_exceptions import ServerAlreadyExists, ServerNotFound
 from .pigs_app_settings.frontend import frontend
-from .states import BootStatus, OperationalStatus
+from .schemas import (
+    AddSwitchIn,
+    BootOsResultOut,
+    BootStatusResultOut,
+    CreateServerIn,
+    HardwareQuery,
+    HealthOut,
+    OpStatusResultOut,
+    ProvisionQuery,
+    PxeQuery,
+    ServerOut,
+    SwitchOut,
+    UpdateBootOsIn,
+    UpdateBootStatusIn,
+    UpdateOpStatusIn,
+)
+from .states import OperationalStatus
 
 log = logging.getLogger(__name__)
 
@@ -83,99 +106,109 @@ def _log_safe(value):
     return repr(value).replace("\n", "").replace("\r", "")
 
 
-def _validated_status(value, enum_cls):
-    """Lowercase + validate ``value`` against ``enum_cls``.
+# --- /api -- open read + health routes -----------------------------------
 
-    Returns the canonical enum string value on success. Aborts with 412
-    if the param is missing, 400 if it is not a known status.
-    """
-    if value is None:
-        abort(412)
-    normalized = value.lower()
-    try:
-        return enum_cls(normalized).value
-    except ValueError:
-        allowed = ", ".join(m.value for m in enum_cls)
-        abort(400, description=f"Invalid status {value!r}. Allowed: {allowed}")
+api = APIBlueprint("api", __name__, tag="Read")
 
 
-api = Blueprint("api", __name__)
-
-
-@api.route("/healthz")
+@api.get("/healthz")
+@api.output(HealthOut)
+@api.doc(summary="Liveness probe", description="Returns 200 if the WSGI process is serving.")
 def healthz():
-    """Liveness: the WSGI process is alive and serving."""
-    return {"status": "ok"}, 200
+    return {"status": "ok"}
 
 
-@api.route("/readyz")
+@api.get("/readyz")
+@api.output(HealthOut)
+@api.doc(summary="Readiness probe", description="Returns 200 if create_app() registered plugins.")
 def readyz():
-    """Readiness: app booted, all plugins loaded.
-
-    The plugin contract has no healthcheck method yet, so this only
-    proves the dataclass exists. Once plugins grow a ``healthcheck()``
-    method we can call into each here.
-    """
-    if current_app.extensions.get("steel_pigs") is None:
-        return {"status": "not_ready", "reason": "plugins not initialized"}, 503
-    return {"status": "ok"}, 200
+    return {"status": "ok"}
 
 
-@api.route("/pxe")
-@api.route("/pxe/configs/<config_file>")
-def get_pxe_script(config_file=None):
-    """Render an iPXE script for the requested server."""
-    log.info("Request to /pxe with params: %s", _log_safe(dict(request.args)))
+@api.get("/pxe")
+@api.input(PxeQuery, location="query")
+@api.doc(
+    summary="Render an iPXE boot script",
+    description=(
+        "Returns an iPXE script tailored to the requested server. Supply "
+        "one of ``server_number``, ``mac``, or the pair ``switch_name`` + "
+        "``switch_port`` to identify the target. The response body is "
+        "text/plain and produced by the configured PXE plugin."
+    ),
+    responses={
+        200: {
+            "description": "iPXE script",
+            "content": {"text/plain": {"schema": {"type": "string"}}},
+        },
+        412: {"description": "No identification params supplied"},
+    },
+)
+def get_pxe_script(query_data):
+    log.info("Request to /pxe with params: %s", _log_safe(query_data))
     p = _plugins()
-    args = request.args
-    # NOTE(major): This dispatch chain is preserved from the original code -
-    # Ant requested both 'number' and 'server_number' aliases.
-    if "number" in args:
-        server_data = p.server_data.get_server_by_number(args["number"])
-    elif "server_number" in args:
-        server_data = p.server_data.get_server_by_number(args["server_number"])
-    elif "mac" in args:
-        mac = p.formatter.format_mac(args["mac"])
-        server_data = p.server_data.get_server_by_mac(mac)
-    else:
-        switch_name = args.get("switch_name")
-        switch_port = args.get("switch_port")
-        if switch_name is None or switch_port is None:
-            abort(412)
+    if query_data["server_number"] is not None:
+        server_data = p.server_data.get_server_by_number(query_data["server_number"])
+    elif query_data["mac"] is not None:
+        server_data = p.server_data.get_server_by_mac(p.formatter.format_mac(query_data["mac"]))
+    elif query_data["switch_name"] is not None and query_data["switch_port"] is not None:
         server_data = p.server_data.get_server_by_switch(
-            p.formatter.format_switch(switch_name),
-            p.formatter.format_port(switch_port),
+            p.formatter.format_switch(query_data["switch_name"]),
+            p.formatter.format_port(query_data["switch_port"]),
         )
+    else:
+        abort(412, "Supply server_number, mac, or (switch_name and switch_port).")
     return p.pxe.generate_ipxe_script(server_data=server_data, request=request)
 
 
-@api.route("/hardware")
-def get_hardware_specs():
-    """iPXE can't match strings with spaces; we strip them and re-emit."""
-    log.info("Request to /hardware with params: %s", _log_safe(dict(request.args)))
-    manufacturer = request.args.get("manufacturer")
-    product = request.args.get("product")
-    if manufacturer is None or product is None:
-        abort(412)
+@api.get("/hardware")
+@api.input(HardwareQuery, location="query")
+@api.doc(
+    summary="Render the hardware-detection iPXE callback",
+    description=(
+        "iPXE can't easily match strings with spaces. This route accepts "
+        "the manufacturer / product strings, strips whitespace, and emits "
+        "an iPXE script that re-assigns the cleaned values."
+    ),
+    responses={
+        200: {
+            "description": "iPXE script",
+            "content": {"text/plain": {"schema": {"type": "string"}}},
+        },
+    },
+)
+def get_hardware_specs(query_data):
+    log.info("Request to /hardware with params: %s", _log_safe(query_data))
     body = render_template(
         "hardware.ipxe",
-        make=manufacturer.replace(" ", ""),
-        model=product.replace(" ", ""),
+        make=query_data["manufacturer"].replace(" ", ""),
+        model=query_data["product"].replace(" ", ""),
     )
     r = make_response(body)
     r.mimetype = "text/plain"
     return r
 
 
-@api.route("/versions")
-@api.route("/versions/json")
+@api.get("/versions")
+@api.doc(
+    summary="Software versions metadata (JSON)",
+    description="Returned shape is determined by the configured version plugin.",
+)
 def get_software_versions_json():
     log.info("Returning version data.")
-    return jsonify(_plugins().version.get_latest_versions())
+    return _plugins().version.get_latest_versions()
 
 
-@api.route("/versions/ipxe")
-@api.route("/versions/ipxe/<project>")
+@api.get("/versions/ipxe")
+@api.get("/versions/ipxe/<project>")
+@api.doc(
+    summary="Software versions formatted as iPXE script",
+    responses={
+        200: {
+            "description": "iPXE-formatted version variables",
+            "content": {"text/plain": {"schema": {"type": "string"}}},
+        },
+    },
+)
 def get_software_versions_ipxe(project=None):
     log.info("Fetching iPXE version script.")
     r = make_response(_plugins().version.get_latest_ipxe(project))
@@ -183,55 +216,30 @@ def get_software_versions_ipxe(project=None):
     return r
 
 
-# --- Legacy mutation endpoints --------------------------------------------
-# These accepted GETs that mutated state, were unauthenticated, and accepted
-# parameters via query string. All three were moved to POST /v1/update/...
-# in this release. The legacy paths respond 405 Method Not Allowed with a
-# pointer at the new endpoint so existing callers fail loudly instead of
-# silently succeeding against an unauth'd surface.
-
-
-def _legacy_405(new_path):
-    response = make_response(
-        jsonify(
-            {
-                "error": "Method Not Allowed",
-                "message": f"This endpoint moved to POST {new_path}",
-            }
-        ),
-        405,
-    )
-    response.headers["Allow"] = "POST"
-    return response
-
-
-@api.route("/update", methods=["GET"])
-@api.route("/update/status", methods=["GET"])
-def legacy_set_boot_status_get():
-    return _legacy_405("/v1/update/status")
-
-
-@api.route("/update/os", methods=["GET"])
-def legacy_set_boot_os_get():
-    return _legacy_405("/v1/update/os")
-
-
-@api.route("/update/opstatus", methods=["GET"])
-def legacy_set_operational_status_get():
-    return _legacy_405("/v1/update/opstatus")
-
-
-@api.route("/provision/os/start")
-def begin_os_provisioning():
-    """Return a provision (kickstart / preseed) script for a device by MAC."""
-    log.info("Fetching provision start: %s", _log_safe(dict(request.args)))
-    server_mac = request.args.get("mac")
-    if server_mac is None:
-        abort(412, description="Missing required param: mac")
+@api.get("/provision/os/start")
+@api.input(ProvisionQuery, location="query")
+@api.doc(
+    summary="Return a kickstart / preseed for a device",
+    description=(
+        "Servers in ``operational_status == online`` get a 204. Servers "
+        "not in ``operational_status == provision`` also get a 204. "
+        "Servers in provision state get the script body."
+    ),
+    responses={
+        200: {
+            "description": "Provision script body",
+            "content": {"text/plain": {"schema": {"type": "string"}}},
+        },
+        204: {"description": "Server already online or not ready to provision"},
+        404: {"description": "Server not found for given MAC"},
+    },
+)
+def begin_os_provisioning(query_data):
+    log.info("Fetching provision start: %s", _log_safe(query_data))
     p = _plugins()
-    server = p.server_data.get_server_by_mac(mac=server_mac)
+    server = p.server_data.get_server_by_mac(mac=query_data["mac"])
     if server is None:
-        abort(404, description=f"Server not found using {server_mac}")
+        abort(404, f"Server not found using {query_data['mac']}")
     op_status = str(server["operational_status"]).lower()
     if op_status == OperationalStatus.ONLINE.value:
         return "", 204
@@ -240,19 +248,9 @@ def begin_os_provisioning():
     return p.provision.get_provision_script(server)
 
 
-# --- v1 mutation API ------------------------------------------------------
-# POST + JSON body, behind @requires_auth. Replaces the legacy /update/*
-# GET endpoints, which now return 405 (see above).
+# --- /v1 -- authenticated mutations --------------------------------------
 
-v1 = Blueprint("v1", __name__, url_prefix="/v1")
-
-
-def _json_field(data, name):
-    """Pull a required field from a parsed JSON body or abort 400."""
-    value = data.get(name)
-    if value is None:
-        abort(400, description=f"Missing required field: {name}")
-    return value
+v1 = APIBlueprint("v1", __name__, url_prefix="/v1", tag="Mutate")
 
 
 def _audit_context(field, server_number, new_value):
@@ -264,12 +262,14 @@ def _audit_context(field, server_number, new_value):
     }
 
 
-@v1.route("/update/status", methods=["POST"])
-@requires_auth
-def v1_set_boot_status():
-    data = request.get_json(silent=True) or {}
-    server_number = _json_field(data, "server_number")
-    boot_status = _validated_status(data.get("boot_status"), BootStatus)
+@v1.post("/update/status")
+@v1.doc(summary="Set a server's boot status")
+@v1.auth_required(auth)
+@v1.input(UpdateBootStatusIn)
+@v1.output(BootStatusResultOut)
+def v1_set_boot_status(json_data):
+    server_number = json_data["server_number"]
+    boot_status = json_data["boot_status"]
     ctx = _audit_context("boot_status", server_number, boot_status)
     result = _plugins().server_data.set_boot_status(server_number, boot_status)
     audit.emit(
@@ -280,15 +280,17 @@ def v1_set_boot_status():
         after=ctx["after"],
         request_id=g.get("request_id"),
     )
-    return jsonify(result)
+    return result
 
 
-@v1.route("/update/os", methods=["POST"])
-@requires_auth
-def v1_set_boot_os():
-    data = request.get_json(silent=True) or {}
-    server_number = _json_field(data, "server_number")
-    boot_os = _json_field(data, "boot_os")
+@v1.post("/update/os")
+@v1.doc(summary="Set a server's boot OS")
+@v1.auth_required(auth)
+@v1.input(UpdateBootOsIn)
+@v1.output(BootOsResultOut)
+def v1_set_boot_os(json_data):
+    server_number = json_data["server_number"]
+    boot_os = json_data["boot_os"]
     ctx = _audit_context("boot_os", server_number, boot_os)
     result = _plugins().server_data.set_boot_os(server_number, boot_os)
     audit.emit(
@@ -299,15 +301,17 @@ def v1_set_boot_os():
         after=ctx["after"],
         request_id=g.get("request_id"),
     )
-    return jsonify(result)
+    return result
 
 
-@v1.route("/update/opstatus", methods=["POST"])
-@requires_auth
-def v1_set_operational_status():
-    data = request.get_json(silent=True) or {}
-    server_number = _json_field(data, "server_number")
-    operational_status = _validated_status(data.get("opstatus"), OperationalStatus)
+@v1.post("/update/opstatus")
+@v1.doc(summary="Set a server's operational status")
+@v1.auth_required(auth)
+@v1.input(UpdateOpStatusIn)
+@v1.output(OpStatusResultOut)
+def v1_set_operational_status(json_data):
+    server_number = json_data["server_number"]
+    operational_status = json_data["opstatus"]
     ctx = _audit_context("operational_status", server_number, operational_status)
     result = _plugins().server_data.set_operational_status(server_number, operational_status)
     audit.emit(
@@ -318,94 +322,109 @@ def v1_set_operational_status():
         after=ctx["after"],
         request_id=g.get("request_id"),
     )
-    return jsonify(result)
+    return result
 
 
-# --- Ingest API -----------------------------------------------------------
-# Fields required when creating a server. These match the NOT NULL columns
-# on ServerDataModel that have no server-side default. boot_status and
-# operational_status are also enum-validated below.
-_REQUIRED_SERVER_FIELDS = (
-    "server_number",
-    "primary_ip",
-    "primary_gw",
-    "primary_nm",
-    "primary_mac",
-    "hostname",
-    "dns_server_primary",
-    "bootstrapped",
-    "boot_os",
-    "boot_os_version",
-    "boot_profile",
-    "boot_status",
-    "operational_status",
-    "ntp_server",
+@v1.post("/servers")
+@v1.doc(
+    summary="Register a new server",
+    description=(
+        "Required: network identity (IPs, MAC, hostname, DNS primary), "
+        "boot template selection (boot_os, boot_os_version, boot_profile), "
+        "and the NTP server. ``bootstrapped``, ``boot_status``, "
+        "``operational_status``, and ``dns_domain_name`` get sensible "
+        "first-boot defaults if omitted."
+    ),
+    responses={
+        201: {"description": "Server registered"},
+        409: {"description": "server_number already exists"},
+        422: {"description": "Validation error"},
+    },
 )
+@v1.auth_required(auth)
+@v1.input(CreateServerIn)
+@v1.output(ServerOut, status_code=201)
+def v1_create_server(json_data):
 
-
-@v1.route("/servers", methods=["POST"])
-@requires_auth
-def v1_create_server():
-    """Register a new server in the inventory."""
-    data = request.get_json(silent=True) or {}
-    missing = [f for f in _REQUIRED_SERVER_FIELDS if data.get(f) is None]
-    if missing:
-        abort(400, description=f"Missing required field(s): {', '.join(missing)}")
-    # Enum-validate the status fields with the same helper used elsewhere.
-    data["boot_status"] = _validated_status(data["boot_status"], BootStatus)
-    data["operational_status"] = _validated_status(data["operational_status"], OperationalStatus)
     try:
-        created = _plugins().server_data.create_server(data)
+        created = _plugins().server_data.create_server(json_data)
     except ServerAlreadyExists as exc:
-        abort(409, description=str(exc))
-    except ValueError as exc:
-        # Unknown columns from the plugin's strict shape check.
-        abort(400, description=str(exc))
+        abort(409, str(exc))
     audit.emit(
         action="create_server",
-        resource=f"server/{data['server_number']}",
+        resource=f"server/{json_data['server_number']}",
         actor=g.get("actor"),
         before=None,
         after=created,
         request_id=g.get("request_id"),
     )
-    return jsonify(created), 201
+    return created
 
 
-@v1.route("/servers/<int:server_number>/switches", methods=["POST"])
-@requires_auth
-def v1_add_switch(server_number):
-    """Attach a switch entry to an existing server."""
-    data = request.get_json(silent=True) or {}
-    switch_name = _json_field(data, "switch_name")
-    switch_port = _json_field(data, "switch_port")
+@v1.post("/servers/<int:server_number>/switches")
+@v1.doc(
+    summary="Attach a switch entry to an existing server",
+    responses={
+        201: {"description": "Switch attached"},
+        404: {"description": "server_number not found"},
+        422: {"description": "Validation error"},
+    },
+)
+@v1.auth_required(auth)
+@v1.input(AddSwitchIn)
+@v1.output(SwitchOut, status_code=201)
+def v1_add_switch(server_number, json_data):
+
     try:
-        created = _plugins().server_data.add_switch(server_number, switch_name, switch_port)
+        created = _plugins().server_data.add_switch(
+            server_number, json_data["switch_name"], json_data["switch_port"]
+        )
     except ServerNotFound as exc:
-        abort(404, description=str(exc))
+        abort(404, str(exc))
     audit.emit(
         action="add_switch",
-        resource=f"server/{server_number}/switch/{switch_name}/{switch_port}",
+        resource=(
+            f"server/{server_number}/switch/{json_data['switch_name']}/{json_data['switch_port']}"
+        ),
         actor=g.get("actor"),
         before=None,
         after=created,
         request_id=g.get("request_id"),
     )
-    return jsonify(created), 201
+    return created
 
 
-def create_app(config_overrides=None, plugins: Plugins | None = None) -> Flask:
-    """Build a configured Flask app.
+# --- App factory ----------------------------------------------------------
 
-    Pass ``plugins`` to inject pre-built plugin instances (used by tests so
-    routes and seeding share the same in-memory plugin state).
+
+def create_app(config_overrides=None, plugins: Plugins | None = None) -> APIFlask:
+    """Build the configured APIFlask app.
+
+    Pass ``plugins`` to inject pre-built plugin instances (used by tests
+    so routes and seeding share the same in-memory plugin state).
     """
-    app = Flask(
+    app = APIFlask(
         __name__,
+        title="Steel PIGS",
+        version="0.4",
+        spec_path="/openapi.json",
+        docs_path="/docs",
         static_folder="static",
         static_url_path="",
         template_folder="templates",
     )
+    app.config["DESCRIPTION"] = "Powerful iPXE Generation Service."
+    app.config["SECURITY_SCHEMES"] = {
+        "BearerAuth": {
+            "type": "http",
+            "scheme": "bearer",
+            "description": "Bearer token supplied via the Authorization header.",
+        }
+    }
+    app.config["TAGS"] = [
+        {"name": "Read", "description": "PXE-boot and health endpoints (unauthenticated)."},
+        {"name": "Mutate", "description": "Inventory mutations (bearer auth required)."},
+    ]
     app.config["SECRET_KEY"] = pigs_config.SECRET_KEY
     if config_overrides:
         app.config.update(config_overrides)


### PR DESCRIPTION
Closes GAPS gap #21 (No API versioning / OpenAPI). Steel PIGS now publishes a Swagger UI at /docs and a machine-readable OpenAPI 3 spec at /openapi.json, both auto-generated from per-route Marshmallow schemas. The schemas double as the runtime validation layer, so the spec stays in sync with actual behavior by construction.

Stack
-----
Flask -> APIFlask 3 (Flask 3 under the hood, so Bootstrap5 + the existing demo frontend keep working). Marshmallow + apispec come along transitively. flask-httpauth handles bearer auth via APIFlask's HTTPTokenAuth wrapper. New dev dep: openapi-spec-validator (for the CI sanity test).

Schemas (steel_pigs/schemas.py)
-------------------------------
Ten input/output/query schemas plus a `_StrictIn` base that rejects unknown fields with 422. The CreateServerIn schema uses load_default for bootstrapped, boot_status, operational_status, and dns_domain_name so a basic register call is a smaller payload (Option B from the discussion).

Auth refactor
-------------
AuthProviderBase now has authenticate_token(token) instead of authenticate(request) -- aligned with the bearer-token model APIFlask / flask-httpauth pass into verify_token callbacks. The custom @requires_auth decorator is gone; routes use @bp.auth_required(auth) which both runtime-checks the token and adds the security scheme to the OpenAPI operation. Decorator ordering puts auth before input validation so unauth'd probes don't get to enumerate schemas.

Audit emit for 401 moved from verify_token to the @auth.error_handler hook so missing-header 401s are also recorded (the verify_token callback only fires when a header was supplied).

Route changes (intentional, since there are no users to break) --------------------------------------------------------------
* Validation errors now return 422 instead of 400. REST-correct, and APIFlask's default; no client compat to preserve.
* /hardware missing required query args returns 422 (was 412).
* Status case-normalization on /v1/update/status is gone. Schema OneOf is case-sensitive; clients send the canonical lowercase value.
* set_boot_os failure body returns {"os_set": "..."} like the success case; the old {"set_boot_os": "..."} asymmetry is gone.
* Legacy GET stubs at /update, /update/status, /update/os, and /update/opstatus deleted. They were 405-redirects for the pre-modernization API; no callers exist to redirect.
* Aliases dropped: ?number= on /pxe (use server_number), /versions/json (use /versions), /pxe/configs/<config_file> (dead variant -- the config_file param was never consumed).

Tests
-----
* TestLegacyMutationRoutes deleted (the routes are gone).
* test_status_normalises_case deleted.
* All 400-on-validation tests updated to 422.
* WWW-Authenticate header assertion loosened to startswith('Bearer') since flask-httpauth tacks on a default realm.
* test_openapi.py (new): verifies /openapi.json validates against the OpenAPI 3 schema, /docs is served, BearerAuth security scheme is published, v1 mutation routes carry the security requirement, and read routes don't.

59 tests total, pre-commit clean.